### PR TITLE
Support for version new ulauncher api (Fix for #4)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ format:
 	@autopep8 --in-place --recursive --aggressive .
 
 link:
-	@ln -s ${EXT_DIR} ~/.cache/ulauncher_cache/extensions/${EXT_NAME}
+	@ln -s ${EXT_DIR} ~/.local/share/ulauncher/extensions/${EXT_NAME}
 
 unlink:
-	@rm -r ~/.cache/ulauncher_cache/extensions/${EXT_NAME}
+	@rm -r ~/.local/share/ulauncher/extensions/${EXT_NAME}

--- a/cheats/manager.py
+++ b/cheats/manager.py
@@ -2,8 +2,16 @@
 
 import os
 import errno
-import glob2
 
+try:
+    import glob2
+except ImportError:
+    import pip
+    if hasattr(pip, 'main'):
+        pip.main(['install', 'glob2'])
+    else:
+        pip._internal.main(['install', 'glob2'])
+    import glob2
 
 class CheatsManager(object):
     """ Class that manages the cheat sheets """

--- a/main.py
+++ b/main.py
@@ -60,7 +60,7 @@ class CheatsExtension(Extension):
                 open_file_action = OpenAction(cheat['path'])
                 open_in_hawkeye_action = RunScriptAction('%s --uri="%s"' % (hawkeye_bin, uri), [])
 
-                if use_hawkeye_default:
+                if use_hawkeye_default == 'true':
                     primary_action = open_in_hawkeye_action
                     secondary_action = open_file_action
                 else:

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,5 @@
 {
-    "manifest_version": "2",
-    "api_version": "1",
+    "required_api_version": "^2.0.0",
     "name": "Cheat Sheets Manager",
     "description": "Provides quick access to your Cheat sheets in multiple formats with quick preview thanks to Hawkeye",
     "developer_name": "Bruno Paz",

--- a/versions.json
+++ b/versions.json
@@ -1,0 +1,4 @@
+[
+  { "required_api_version": "^1.0.0", "commit": "master" },
+  { "required_api_version": "^2.0.0", "commit": "v5" }
+]

--- a/versions.json
+++ b/versions.json
@@ -1,4 +1,3 @@
 [
-  { "required_api_version": "^1.0.0", "commit": "master" },
-  { "required_api_version": "^2.0.0", "commit": "v5" }
+  { "required_api_version": "^2.0.0", "commit": "master" },
 ]


### PR DESCRIPTION
Hi there, 
I found the plugin and wanted to help to make it suitable for the new API version. I just made the changes I saw necessary for the program to work. If any bug occurs, I gladly help to fix it.

If approved, it only allows for using the new API version. You could create a branch for the old version before and you or I add one line to versions.json to support both the old and new API, it's up to you. If you don't care about legacy support, you may just approve it if you like.

Kind regards, Simon